### PR TITLE
Automatically enable single language mode (#1235726)

### DIFF
--- a/installclass_atomic.py
+++ b/installclass_atomic.py
@@ -19,6 +19,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import logging
+log = logging.getLogger("anaconda")
+
 from pyanaconda.installclasses.fedora import FedoraBaseInstallClass
 from pyanaconda.constants import *
 from pyanaconda.product import *
@@ -27,6 +30,7 @@ from pyanaconda import nm
 from pyanaconda import iutil
 import types
 from pyanaconda.kickstart import getAvailableDiskSpace
+from pyanaconda.flags import flags
 from blivet.partspec import PartSpec
 from blivet.autopart import swapSuggestion
 from blivet.platform import platform
@@ -36,6 +40,12 @@ class AtomicInstallClass(FedoraBaseInstallClass):
     name = "Atomic Host"
     sortPriority = 11000
     hidden = False
+
+    def configure(self, anaconda):
+        FedoraBaseInstallClass.configure(self, anaconda)
+        # Atomic installations are always single language (#1235726)
+        log.info("Automatically enabling single language mode for %s installation.", self.name)
+        flags.singlelang = True
 
     def setDefaultPartitioning(self, storage):
         # 3GB is obviously arbitrary, but we have to pick some default.


### PR DESCRIPTION
Automatically enable the single language mode for Atomic installations.

Atomic installations are always single language (and en_US.UTF-8) so
the ability to interactively change language settings during the
installation can be actually harmful (see bug 1235726 for more
details).

The single language mode takes care of this by disabling interactive
language configuration during the installation.
